### PR TITLE
Fix mime-type in response

### DIFF
--- a/src/routes/fetchAudio.js
+++ b/src/routes/fetchAudio.js
@@ -24,7 +24,7 @@ module.exports = {
               const response = reply(fs.createReadStream(process.env.SAVE_AUDIO_PATH + `${fileId}.wav`));
               response.type('audio/wav');
               if (request.query.download=='yes')
-                response.type('content-disposition', 'attachment; filename='+fileId+'.wav');
+                response.type('attachment; filename='+fileId+'.wav');
             } else {
               reply('you are not authorized to listen to this call');
             }


### PR DESCRIPTION
When downloading as opposed to playing a recording we have to set the content disposition to be an attachment rather than a wav file. Fix error on last attempt!